### PR TITLE
Also change command-line conditions for ostree-remount service

### DIFF
--- a/src/boot/ostree-remount.service
+++ b/src/boot/ostree-remount.service
@@ -18,7 +18,8 @@
 [Unit]
 Description=OSTree Remount OS/ bind mounts
 DefaultDependencies=no
-ConditionKernelCommandLine=ostree
+ConditionKernelCommandLine=|ostree
+ConditionKernelCommandLine=|ostree.bootcsum
 OnFailure=emergency.service
 Conflicts=umount.target
 After=-.mount


### PR DESCRIPTION
Similarly to the change in `ostree-prepare-root.service`, this service also needs to allow for `ostree.bootcsum` in the kernel command-line, otherwise it will not run.